### PR TITLE
Glob artifact path when  gradle-project-path is '.' + execution-only-caches gradle option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,10 +49,12 @@ runs:
       id: metadata
       shell: bash
       run: |
-        ARTIFACT_PATH=${{ inputs.working-directory }}
+        WORKING_DIRECTORY=${{ inputs.working-directory }}
         GRADLE_PROJECT_PATH=${{  inputs.gradle-project-path }}
-        if [[ "$GRADLE_PROJECT_PATH" != "." ]]; then
-          ARTIFACT_PATH="$ARTIFACT_PATH/$GRADLE_PROJECT_PATH"
+        if [[ "$GRADLE_PROJECT_PATH" == "." ]]; then
+          ARTIFACT_PATH="$WORKING_DIRECTORY/**"
+        else
+          ARTIFACT_PATH="$WORKING_DIRECTORY/$GRADLE_PROJECT_PATH"
         fi
         echo "artifact-path=$ARTIFACT_PATH" >> $GITHUB_OUTPUT
 

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,14 @@ description: |
   This actions will also annotate the PR or commit with the failed tests.
 
 inputs:
+  execution-only-caches:
+    description: |
+      Activates only the caches that are relevant for executing gradle command.
+      This is helpful when build job executes multiple gradle commands sequentially.
+      Then the caching is implemented in the very first one, and the subsequent should be marked
+      with execution-only-caches: true
+    required: false
+    default: 'false'
   gradle-properties:
     description: Content of a gradle.properties file that will be passed to the gradle runner.
     required: false
@@ -66,6 +74,7 @@ runs:
         gradle-dependencies-cache-key: ${{ inputs.gradle-dependencies-cache-key }}
         arguments: -p ${{ inputs.gradle-project-path }} ci-${{ inputs.task-name }}
         properties: ${{ inputs.gradle-properties }}
+        execution-only-caches: ${{ inputs.execution-only-caches }}
 
     - name: Upload report
       uses: actions/upload-artifact@v3

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,17 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: metadata
+      id: metadata
+      shell: bash
+      run: |
+        ARTIFACT_PATH=${{ inputs.working-directory }}
+        GRADLE_PROJECT_PATH=${{  inputs.gradle-project-path }}
+        if [[ "$GRADLE_PROJECT_PATH" != "." ]]; then
+          ARTIFACT_PATH="$ARTIFACT_PATH/$GRADLE_PROJECT_PATH"
+        fi
+        echo "artifact-path=$ARTIFACT_PATH" >> $GITHUB_OUTPUT
+
     - name: Run tests
       uses: burrunan/gradle-cache-action@v1
       with:
@@ -61,7 +72,7 @@ runs:
         name: ${{ inputs.task-name }}-report
         retention-days: ${{ inputs.report-retention-days }}
         path: |
-          ${{ inputs.working-directory }}/${{ inputs.gradle-project-path }}/build/reports/tests/${{ inputs.task-name }}/
+          ${{ steps.metadata.outputs.artifact-path }}/build/reports/tests/${{ inputs.task-name }}/
 
     - name: Upload results
       uses: actions/upload-artifact@v3
@@ -71,8 +82,8 @@ runs:
         retention-days: 1
         if-no-files-found: error
         path: |
-          ${{ inputs.working-directory }}/${{ inputs.gradle-project-path }}/build/test-results/${{ inputs.task-name }}/
-          !${{ inputs.working-directory }}/${{ inputs.gradle-project-path }}/build/test-results/${{ inputs.task-name }}/binary
+          ${{ steps.metadata.outputs.artifact-path }}/build/test-results/${{ inputs.task-name }}/
+          !${{ steps.metadata.outputs.artifact-path }}/build/test-results/${{ inputs.task-name }}/binary
 
     - name: Upload coverage results
       uses: actions/upload-artifact@v3
@@ -82,7 +93,7 @@ runs:
         retention-days: 1
         if-no-files-found: error
         path: |
-          ${{ inputs.working-directory }}/${{ inputs.gradle-project-path }}/build/jacoco/${{ inputs.task-name }}.exec
+          ${{ steps.metadata.outputs.artifact-path }}/build/jacoco/${{ inputs.task-name }}.exec
 
     - name: Create annotations
       uses: mikepenz/action-junit-report@v3
@@ -90,4 +101,4 @@ runs:
       with:
         check_name: ${{ inputs.task-name }} report
         report_paths: |
-          ${{ inputs.working-directory }}/${{ inputs.gradle-project-path }}/build/test-results/${{ inputs.task-name }}/TEST-*.xml
+          ${{ steps.metadata.outputs.artifact-path }}/build/test-results/${{ inputs.task-name }}/TEST-*.xml


### PR DESCRIPTION
Quand on passe pas de sous-projet gradle,  ça fait une erreur à cause du `././`.  J'ai remplacé par des `**` pour uploader tous les artifact trouvé dans les sous projet.

`execution-only-caches` serait mieux pour les step subséquente de build dans la même job

Testé dans un projet de librairie kotlin : https://github.com/kronostechnologies/auth-kotlin/actions/runs/5122059300

Testé non régression dans account-service : https://github.com/kronostechnologies/account-service/actions/runs/5122080404