### PR TITLE
feat: use gradle-build-action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,14 +6,6 @@ description: |
   This actions will also annotate the PR or commit with the failed tests.
 
 inputs:
-  execution-only-caches:
-    description: |
-      Activates only the caches that are relevant for executing gradle command.
-      This is helpful when build job executes multiple gradle commands sequentially.
-      Then the caching is implemented in the very first one, and the subsequent should be marked
-      with execution-only-caches: true
-    required: false
-    default: 'false'
   gradle-properties:
     description: Content of a gradle.properties file that will be passed to the gradle runner.
     required: false
@@ -23,12 +15,10 @@ inputs:
       Defaults to the root project.
     required: true
     default: "."
-  gradle-dependencies-cache-key:
-    description: Extra files to take into account for ~/.gradle/caches dependencies
+  read-only-cache:
+    description: If set to true, the action will only read from the cache and will not write to it.
     required: true
-    default: |
-      buildSrc/**/Dependencies.kt
-      gradle/libs.versions.toml
+    default: "true"
   report-retention-days:
     description: Duration in days to preserve reports.
     required: true
@@ -66,15 +56,32 @@ runs:
         fi
         echo "artifact-path=$ARTIFACT_PATH" >> $GITHUB_OUTPUT
 
+    - name: Process gradle properties
+      id: gradle-properties
+      shell: python
+      env:
+        GRADLE_PROPERTIES: ${{ inputs.gradle-properties }}
+      run: |
+        import os
+
+        properties_list: list[str] = [line for line in (line.strip() for line in os.environ.get('GRADLE_PROPERTIES').splitlines()) if line]
+        properties = list(map(lambda x: f'-P{x}' if not x.startswith('-P') else x, properties_list))
+
+        with open(os.environ.get('GITHUB_OUTPUT'), 'a') as output_file:
+          output_file.write('gradle-properties=')
+          output_file.write(' '.join(properties))
+          output_file.write('\n')
+
     - name: Run tests
-      uses: burrunan/gradle-cache-action@v1
+      uses: gradle/gradle-build-action@v2
       with:
         gradle-version: wrapper
         build-root-directory: ${{ inputs.working-directory }}
-        gradle-dependencies-cache-key: ${{ inputs.gradle-dependencies-cache-key }}
-        arguments: -p ${{ inputs.gradle-project-path }} ci-${{ inputs.task-name }}
-        properties: ${{ inputs.gradle-properties }}
-        execution-only-caches: ${{ inputs.execution-only-caches }}
+        cache-read-only: ${{ inputs.read-only-cache }}
+        arguments: |
+          -p ${{ inputs.gradle-project-path }}
+          ci-${{ inputs.task-name }}
+          ${{ steps.gradle-properties.outputs.gradle-properties }}
 
     - name: Upload report
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
La passe-passe des gradle-properties c'est pour pas faire de breaking change dans les utilisations.